### PR TITLE
Incorporate updates to type MD in package grpc/metadata

### DIFF
--- a/cache_control.go
+++ b/cache_control.go
@@ -57,7 +57,7 @@ func Internal_WithCacheControl(ctx context.Context) (context.Context, *CacheCont
 // code-genned CachedXyzServer wrapper methods. It should not be
 // called by user code.
 func Internal_SetCacheControlTrailer(ctx context.Context, cc CacheControl) error {
-	return grpc.SetTrailer(ctx, metadata.MD{"cache-control:max-age": cc.MaxAge.String()})
+	return grpc.SetTrailer(ctx, metadata.MD{"cache-control:max-age": []string{cc.MaxAge.String()}})
 }
 
 // TODO(sqs): warn if nil?
@@ -70,8 +70,8 @@ func cacheControlFromContext(ctx context.Context) *CacheControl {
 // server's CacheControl response metadata.
 func cacheControlFromMetadata(md metadata.MD) (*CacheControl, error) {
 	var cc *CacheControl
-	if maxAgeStr, present := md["cache-control:max-age"]; present {
-		maxAge, err := time.ParseDuration(maxAgeStr)
+	if maxAgeStrs, present := md["cache-control:max-age"]; present && len(maxAgeStrs) > 0 {
+		maxAge, err := time.ParseDuration(maxAgeStrs[0])
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The metadata.MD type in google.golang.org/grpc/metadata has changed from map[string]string to map[string][]string.
